### PR TITLE
Fixed script URL

### DIFF
--- a/Windows/Execution/CloseAllApplications_Windows/close_all_app.ps1
+++ b/Windows/Execution/CloseAllApplications_Windows/close_all_app.ps1
@@ -1,5 +1,5 @@
 # Download Python script
-$scriptUrl = "https://raw.githubusercontent.com/aleff-github/my-flipper-shits/main/CloseAllApplications_Windows/script.py"
+$scriptUrl = "https://raw.githubusercontent.com/aleff-github/my-flipper-shits/main/Windows/Execution/CloseAllApplications_Windows/script.py"
 $savePath = "$env:temp\script.py"
 (New-Object System.Net.WebClient).DownloadFile($scriptUrl, $savePath)
 


### PR DESCRIPTION
Updated the script URL to match the different file structure of the repo. (Files now are contained within `<Operating System>/<Payload Category>` instead of being in the root directory).
There is also an issue with all of the `bit.ly` links where they have not been updated with the different file structure